### PR TITLE
Add debugging for failed requests resource graph requests.

### DIFF
--- a/package/bin/ta_azure_utils/utils.py
+++ b/package/bin/ta_azure_utils/utils.py
@@ -280,6 +280,7 @@ def get_json_resources_by_query(helper=None, url=None, session=None, query=None,
         response_json = None
         response_json = json.loads(r.content)
     except Exception as e:
+        helper.log_debug("Request failed: url: %s, data: %s, response_status: %s, response_content: %s" % (url, data, r.status_code, response.content) 
         raise e
     finally:
         t1 = time.time()


### PR DESCRIPTION
We are seeing a 400 Bad requests while using the resource_graph modular input. This commit would allow us to understand the error better.

```
Traceback (most recent call last):
  File "/opt/splunk/etc/apps/TA-MS-AAD/lib/splunktaucclib/modinput_wrapper/base_modinput.py", line 140, in stream_events
    self.collect_events(ew)
  File "/opt/splunk/etc/apps/TA-MS-AAD/bin/azure_resource_graph.py", line 109, in collect_events
    response = azutils.get_json_resources_by_query(helper=helper, url=url, session=session, query=query, subscription_ids=subscription_ids.split(","), options=options)
  File "/opt/splunk/etc/apps/TA-MS-AAD/bin/ta_azure_utils/utils.py", line 283, in get_json_resources_by_query
    raise e
  File "/opt/splunk/etc/apps/TA-MS-AAD/bin/ta_azure_utils/utils.py", line 279, in get_json_resources_by_query
    r.raise_for_status()
  File "/opt/splunk/etc/apps/TA-MS-AAD/lib/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://management.azure.com/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01
```