### PR TITLE
Adding Service Principal Input - WiP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 4.2.0
+* Added input for Azure AD Service Principals. [Issue #35](https://github.com/splunk/splunk-add-on-microsoft-azure/issues/35)
+
+
 # Version 4.1.0
 * Added input for Azure AD Applications. [Issue #27](https://github.com/splunk/splunk-add-on-microsoft-azure/issues/27)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This add-on is built with Splunk's [UCC Generator](https://github.com/splunk/add
 
 Example:
 
-    ucc-gen --ta-version=4.1.0
+    ucc-gen --ta-version=4.2.0
 
 The add-on will be built in an `output` directory in the root of the repository.
 

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "TA-MS-AAD",
         "displayName": "Splunk Add-on for Microsoft Azure",
-        "version": "4.1.0",
+        "version": "4.2.0",
         "apiVersion": "3.0.0",
         "restRoot": "TA_MS_AAD",
         "schemaVersion": "0.0.3"
@@ -1154,6 +1154,171 @@
                             "required": true,
                             "type": "text",
                             "defaultValue": "azure:aad:application",
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "minLength": 0,
+                                    "maxLength": 8192,
+                                    "errorMsg": "Max length of text input is 8192"
+                                }
+                            ]
+                        },
+                        {
+                            "field": "endpoint",
+                            "label": "Endpoint",
+                            "help": "",
+                            "required": true,
+                            "type": "singleSelect",
+                            "defaultValue": "v1.0",
+                            "options": {
+                                "disableSearch": true,
+                                "autoCompleteFields": [
+                                    {
+                                        "value": "v1.0",
+                                        "label": "v1.0"
+                                    },
+                                    {
+                                        "value": "beta",
+                                        "label": "Beta"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "template": "input_with_helper",
+                    "name": "MS_AAD_service_principal",
+                    "title": "Azure Active Directory Service Principals",
+                    "entity": [
+                        {
+                            "field": "name",
+                            "label": "Name",
+                            "type": "text",
+                            "help": "Enter a unique name for the data input",
+                            "required": true,
+                            "validators": [
+                                {
+                                    "type": "regex",
+                                    "pattern": "^[a-zA-Z]\\w*$",
+                                    "errorMsg": "Input Name must start with a letter and followed by alphabetic letters, digits or underscores."
+                                },
+                                {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 100,
+                                    "errorMsg": "Length of input name should be between 1 and 100"
+                                }
+                            ]
+                        },
+                        {
+                            "field": "interval",
+                            "label": "Interval",
+                            "type": "text",
+                            "required": true,
+                            "defaultValue": 86400,
+                            "help": "Time interval of input in seconds.",
+                            "validators": [
+                                {
+                                    "type": "regex",
+                                    "pattern": "^\\-[1-9]\\d*$|^\\d*$",
+                                    "errorMsg": "Interval must be an integer."
+                                }
+                            ]
+                        },
+                        {
+                            "field": "index",
+                            "label": "Index",
+                            "type": "singleSelect",
+                            "defaultValue": "default",
+                            "options": {
+                                "endpointUrl": "data/indexes",
+                                "createSearchChoice": true,
+                                "denyList": "^_.*$"
+                            },
+                            "required": true,
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 80,
+                                    "errorMsg": "Length of index name should be between 1 and 80."
+                                }
+                            ]
+                        },
+                        {
+                            "field": "azure_app_account",
+                            "label": "Azure App Account",
+                            "help": "",
+                            "required": true,
+                            "type": "singleSelect",
+                            "options": {
+                                "referenceName": "account"
+                            }
+                        },
+                        {
+                            "field": "tenant_id",
+                            "label": "Tenant ID",
+                            "help": "a.k.a. Directory ID",
+                            "required": true,
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "minLength": 0,
+                                    "maxLength": 8192,
+                                    "errorMsg": "Max length of text input is 8192"
+                                }
+                            ]
+                        },
+                        {
+                            "field": "filter",
+                            "label": "Query Parameters (optional)",
+                            "help": "Example: $select=id,appId",
+                            "required": false,
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "minLength": 0,
+                                    "maxLength": 8192,
+                                    "errorMsg": "Max length of text input is 8192"
+                                },
+                                {
+                                    "type": "regex",
+                                    "errorMsg": "Value must start with $",
+                                    "pattern": "^\\$"
+                                }
+                            ]
+                        },
+                        {
+                            "field": "environment",
+                            "label": "Environment",
+                            "help": "",
+                            "required": true,
+                            "type": "singleSelect",
+                            "defaultValue": "public",
+                            "options": {
+                                "disableSearch": true,
+                                "autoCompleteFields": [
+                                    {
+                                        "value": "public",
+                                        "label": "Azure Public"
+                                    },
+                                    {
+                                        "value": "gov",
+                                        "label": "Azure Government"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "field": "service_principal_sourcetype",
+                            "label": "Service Principal Sourcetype",
+                            "help": "",
+                            "required": true,
+                            "type": "text",
+                            "defaultValue": "azure:aad:service_principal",
                             "validators": [
                                 {
                                     "type": "string",

--- a/package/app.manifest
+++ b/package/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA-MS-AAD",
-      "version": "4.1.0"
+      "version": "4.2.0"
     },
     "author": [
       {

--- a/package/bin/MS_AAD_service_principal.py
+++ b/package/bin/MS_AAD_service_principal.py
@@ -1,0 +1,155 @@
+# encoding = utf-8
+'''
+
+Copyright 2020 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+'''
+import os
+import sys
+import time
+import datetime
+import json
+import import_declare_test
+from splunklib import modularinput as smi
+import traceback
+import requests
+from splunklib import modularinput as smi
+from solnlib import conf_manager
+from solnlib import log
+from solnlib.modular_input import checkpointer
+from splunktaucclib.modinput_wrapper import base_modinput  as base_mi 
+import requests
+import ta_azure_utils.auth as azauth
+import ta_azure_utils.utils as azutils
+
+bin_dir = os.path.basename(__file__)
+
+class ModInputMS_AAD_service_principal(base_mi.BaseModInput):
+
+    def __init__(self):
+        use_single_instance = False
+        super(ModInputMS_AAD_service_principal, self).__init__("ta_ms_aad", "MS_AAD_service_principal", use_single_instance)
+        self.global_checkbox_fields = None
+
+    def get_scheme(self):
+        """overloaded splunklib modularinput method"""
+        scheme = super(ModInputMS_AAD_service_principal, self).get_scheme()
+        scheme.title = ("Azure Active Directory Service Principals")
+        scheme.description = ("Go to the add-on\'s configuration UI and configure modular inputs under the Inputs menu.")
+        scheme.use_external_validation = True
+        scheme.streaming_mode_xml = True
+
+        scheme.add_argument(smi.Argument("name", title="Name",
+                                         description="",
+                                         required_on_create=True))
+        scheme.add_argument(smi.Argument("azure_app_account", title="Azure App Account",
+                                         description="",
+                                         required_on_create=True,
+                                         required_on_edit=False))
+        scheme.add_argument(smi.Argument("tenant_id", title="Tenant ID",
+                                         description="a.k.a. Directory ID",
+                                         required_on_create=True,
+                                         required_on_edit=False))
+        scheme.add_argument(smi.Argument("filter", title="Query Parameters (optional)",
+                                         description="Example: $filter=startswith(displayName,\'a\')",
+                                         required_on_create=False,
+                                         required_on_edit=False))
+        scheme.add_argument(smi.Argument("environment", title="Environment",
+                                         description="",
+                                         required_on_create=True,
+                                         required_on_edit=False))
+        scheme.add_argument(smi.Argument("service_principal_sourcetype", title="Service Principal Sourcetype",
+                                         description="",
+                                         required_on_create=True,
+                                         required_on_edit=False))
+        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+                                         description="",
+                                         required_on_create=True,
+                                         required_on_edit=False))
+        return scheme
+
+    def get_app_name(self):
+        return "TA-MS-AAD"
+
+    def validate_input(helper, definition):
+       pass
+    
+
+    def collect_events(helper, ew):
+        global_account = helper.get_arg("azure_app_account")
+        client_id = global_account["username"]
+        client_secret = global_account["password"]
+        tenant_id = helper.get_arg("tenant_id")
+        event_source = "%s:tenant_id:%s" % (helper.input_type, tenant_id)
+        source_type = helper.get_arg("service_principal_sourcetype")
+        filter = helper.get_arg("filter")
+        endpoint = helper.get_arg("endpoint")
+        input_name = helper.get_input_stanza_names()
+        
+        environment = helper.get_arg("environment")
+        graph_base_url = azutils.get_environment_graph(environment)
+        
+        session = azauth.get_graph_session(client_id, client_secret, tenant_id, environment, helper)
+        if(session):
+            helper.log_debug("_Splunk_ input_name=%s Collecting service principals data." % input_name)
+            url = graph_base_url + "/%s/servicePrincipals" % endpoint
+            if(filter):
+                url = "%s?%s" % (url, filter)
+    
+            response = azutils.get_items_batch_session(helper=helper, url=url, session=session)
+            items = None if response == None else response['value']
+    
+            while items:
+                for item in items:
+                    event = helper.new_event(
+                            data = json.dumps(item),
+                            source = event_source.lower(), 
+                            index = helper.get_output_index(),
+                            sourcetype = source_type)
+                    ew.write_event(event)
+    
+                sys.stdout.flush()
+                response = azutils.handle_nextLink(helper=helper, response=response, session=session)
+                items = None if response == None else response['value']
+    
+        else:
+            helper.log_error("_Splunk_ Unable to obtain access token")
+
+    def get_account_fields(self):
+        account_fields = []
+        account_fields.append("azure_app_account")
+        return account_fields
+
+    def get_checkbox_fields(self):
+        checkbox_fields = []
+        return checkbox_fields
+
+    def get_global_checkbox_fields(self):
+        if self.global_checkbox_fields is None:
+            checkbox_name_file = os.path.join(bin_dir, 'global_checkbox_param.json')
+            try:
+                if os.path.isfile(checkbox_name_file):
+                    with open(checkbox_name_file, 'r') as fp:
+                        self.global_checkbox_fields = json.load(fp)
+                else:
+                    self.global_checkbox_fields = []
+            except Exception as e:
+                self.log_error('Get exception when loading global checkbox parameter names. ' + str(e))
+                self.global_checkbox_fields = []
+        return self.global_checkbox_fields
+
+if __name__ == "__main__":
+    exitcode = ModInputMS_AAD_service_principal().run(sys.argv)
+    sys.exit(exitcode)

--- a/package/default/eventtypes.conf
+++ b/package/default/eventtypes.conf
@@ -6,6 +6,9 @@ search = (sourcetype=ms:aad:user OR sourcetype=azure:aad:user)
 
 [azure_aad_multifactor_auth]
 search = (sourcetype=ms:aad:signin OR sourcetype=azure:aad:signin) "mfaDetail.authDetail"!=null
+
+[azure_aad_service_principal]
+search = sourcetype=azure:aad:service_principal
 # Backward compatibility
 
 [ms_aad_signin]

--- a/package/default/inputs.conf
+++ b/package/default/inputs.conf
@@ -14,6 +14,10 @@ python.version = python3
 endpoint = v1.0
 python.version = python3
 
+[MS_AAD_service_principal]
+endpoint = v1.0
+python.version = python3
+
 [MS_AAD_audit]
 endpoint = v1.0
 python.version = python3
@@ -61,4 +65,3 @@ python.version = python3
 
 [azure_topology_man]
 python.version = python3
-

--- a/package/default/props.conf
+++ b/package/default/props.conf
@@ -99,6 +99,16 @@ SHOULD_LINEMERGE = 0
 TRUNCATE = 0
 DATETIME_CONFIG = CURRENT
 
+[azure:aad:service_principal]
+SHOULD_LINEMERGE = 0
+TRUNCATE = 0
+# CIM Mapping
+FIELDALIAS-azure_aad_user_user = displayName AS user
+FIELDALIAS-azure_aad_user_enabled = accountEnabled AS enabled
+FIELDALIAS-azure_aad_user_user_id = servicePrincipalName AS user_id
+EVAL-vendor_product = "Microsoft Azure Active Directory"
+DATETIME_CONFIG = CURRENT
+
 [ms:aad:audit]
 SHOULD_LINEMERGE = 0
 TIME_PREFIX = \"activityDateTime\"\:\s*\"

--- a/package/default/props.conf
+++ b/package/default/props.conf
@@ -103,9 +103,9 @@ DATETIME_CONFIG = CURRENT
 SHOULD_LINEMERGE = 0
 TRUNCATE = 0
 # CIM Mapping
-FIELDALIAS-azure_aad_user_user = displayName AS user
-FIELDALIAS-azure_aad_user_enabled = accountEnabled AS enabled
-FIELDALIAS-azure_aad_user_user_id = servicePrincipalName AS user_id
+FIELDALIAS-azure_aad_service_principal_user = displayName AS user
+FIELDALIAS-azure_aad_service_principal_enabled = accountEnabled AS enabled
+FIELDALIAS-azure_aad_service_principal_user_id = servicePrincipalName AS user_id
 EVAL-vendor_product = "Microsoft Azure Active Directory"
 DATETIME_CONFIG = CURRENT
 

--- a/package/default/tags.conf
+++ b/package/default/tags.conf
@@ -11,6 +11,11 @@ cloud = enabled
 authentication = enabled
 cloud = enabled
 multifactor = enabled
+
+[eventtype=azure_aad_service_principal]
+inventory = enabled
+user = enabled
+cloud = enabled
 # Backward compatibility
 
 [eventtype=ms_aad_signin]


### PR DESCRIPTION
Unable to build the package successfully, GUI input page throws a bunch of 500 errors. 
Latest version of UCC does not like the globalConfig file, Splunk inputs page doesn't load correctly on the GUI after attempting to resolve the errors relating to an updated schema. 

Attempted to build the app with these two app versions, however still unable to generate a sound config. 
```
pip install --force-reinstall -v "splunk-add-on-ucc-framework==5.28.4"
pip install --force-reinstall -v "splunk-packaging-toolkit==1.0.1"
```

Suspected splunk-packaging-toolkit compatibility issues with app.manifest schema version 1.0.0, attempts to update to v2.0.0 still return errors. 

```
AxiosError: Request failed with status code 500
Failed to load inputs page This is normal on Splunk search heads as they do not require an Input page. Check your installation or return to the configuration page.
```