### PR TITLE
renamed input parameter endpoint to api_version

### DIFF
--- a/globalConfig.json
+++ b/globalConfig.json
@@ -359,8 +359,8 @@
                         "label": "User Sourcetype"
                     },
                     {
-                        "field": "endpoint",
-                        "label": "Endpoint"
+                        "field": "api_version",
+                        "label": "API Version"
                     },
                     {
                         "field": "audit_sourcetype",
@@ -611,8 +611,8 @@
                             ]
                         },
                         {
-                            "field": "endpoint",
-                            "label": "Endpoint",
+                            "field": "api_version",
+                            "label": "API Version",
                             "help": "",
                             "required": true,
                             "type": "singleSelect",
@@ -769,8 +769,8 @@
                             ]
                         },
                         {
-                            "field": "endpoint",
-                            "label": "Endpoint",
+                            "field": "api_version",
+                            "label": "API Version",
                             "help": "",
                             "required": true,
                             "type": "singleSelect",
@@ -927,8 +927,8 @@
                             ]
                         },
                         {
-                            "field": "endpoint",
-                            "label": "Endpoint",
+                            "field": "api_version",
+                            "label": "API Version",
                             "help": "",
                             "required": true,
                             "type": "singleSelect",
@@ -1085,8 +1085,8 @@
                             ]
                         },
                         {
-                            "field": "endpoint",
-                            "label": "Endpoint",
+                            "field": "api_version",
+                            "label": "API Version",
                             "help": "",
                             "required": true,
                             "type": "singleSelect",
@@ -1280,8 +1280,8 @@
                             ]
                         },
                         {
-                            "field": "endpoint",
-                            "label": "Endpoint",
+                            "field": "api_version",
+                            "label": "API Version",
                             "help": "",
                             "required": true,
                             "type": "singleSelect",
@@ -1447,8 +1447,8 @@
                             ]
                         },
                         {
-                            "field": "endpoint",
-                            "label": "Endpoint",
+                            "field": "api_version",
+                            "label": "API Version",
                             "help": "",
                             "required": true,
                             "type": "singleSelect",
@@ -1585,8 +1585,8 @@
                             ]
                         },
                         {
-                            "field": "endpoint",
-                            "label": "Endpoint",
+                            "field": "api_version",
+                            "label": "API Version",
                             "help": "",
                             "required": false,
                             "type": "singleSelect",
@@ -1758,8 +1758,8 @@
                             ]
                         },
                         {
-                            "field": "endpoint",
-                            "label": "Endpoint",
+                            "field": "api_version",
+                            "label": "API Version",
                             "help": "",
                             "required": false,
                             "type": "singleSelect",

--- a/package/bin/MS_AAD_app.py
+++ b/package/bin/MS_AAD_app.py
@@ -74,7 +74,7 @@ class ModInputMS_AAD_app(base_mi.BaseModInput):
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
-        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+        scheme.add_argument(smi.Argument("api_version", title="API Version",
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
@@ -95,7 +95,7 @@ class ModInputMS_AAD_app(base_mi.BaseModInput):
         event_source = "%s:tenant_id:%s" % (helper.input_type, tenant_id)
         source_type = helper.get_arg("app_sourcetype")
         filter = helper.get_arg("filter")
-        endpoint = helper.get_arg("endpoint")
+        api_version = helper.get_arg("api_version")
         input_name = helper.get_input_stanza_names()
         
         environment = helper.get_arg("environment")
@@ -104,7 +104,7 @@ class ModInputMS_AAD_app(base_mi.BaseModInput):
         session = azauth.get_graph_session(client_id, client_secret, tenant_id, environment, helper)
         if(session):
             helper.log_debug("_Splunk_ input_name=%s Collecting application data." % input_name)
-            url = graph_base_url + "/%s/applications/" % endpoint
+            url = graph_base_url + "/%s/applications/" % api_version
             if(filter):
                 url = "%s?%s" % (url, filter)
             

--- a/package/bin/MS_AAD_audit.py
+++ b/package/bin/MS_AAD_audit.py
@@ -105,7 +105,7 @@ class ModInputMS_AAD_audit(base_mi.BaseModInput):
                                          description="Advanced: number of seconds to subtract from the end date of the query. This helps accommodate near real-time events toward the end of a query that may arrive non sequentially.",
                                          required_on_create=True,
                                          required_on_edit=False))
-        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+        scheme.add_argument(smi.Argument("api_version", title="API Version",
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
@@ -145,7 +145,7 @@ class ModInputMS_AAD_audit(base_mi.BaseModInput):
         source_type = helper.get_arg("audit_sourcetype")
         input_name = helper.get_input_stanza_names()
     
-        endpoint = helper.get_arg("endpoint")
+        api_version = helper.get_arg("api_version")
         
         environment = helper.get_arg("environment")
         graph_base_url = azutils.get_environment_graph(environment)
@@ -156,12 +156,12 @@ class ModInputMS_AAD_audit(base_mi.BaseModInput):
         if(session):
             if(query_window_size > 0):
                 end_date = azutils.get_end_date(helper, query_date, query_window_size)
-                url = graph_base_url + "/%s/auditLogs/directoryAudits?$orderby=activityDateTime&$filter=activityDateTime+ge+%s+and+activityDateTime+le+%s" % (endpoint, query_date, end_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ'))
+                url = graph_base_url + "/%s/auditLogs/directoryAudits?$orderby=activityDateTime&$filter=activityDateTime+ge+%s+and+activityDateTime+le+%s" % (api_version, query_date, end_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ'))
                 helper.log_debug("_Splunk_ input_name=%s Query limit specified: %s" % (input_name, str(query_window_size)))
             else:
                 time_throttle_unformatted = datetime.datetime.utcnow() - datetime.timedelta(seconds=query_backoff_throttle)
                 time_throttle = time_throttle_unformatted.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-                url = graph_base_url + "/%s/auditLogs/directoryAudits?$orderby=activityDateTime&$filter=activityDateTime+gt+%s+and+activityDateTime+le+%s" % (endpoint, query_date, time_throttle)
+                url = graph_base_url + "/%s/auditLogs/directoryAudits?$orderby=activityDateTime&$filter=activityDateTime+gt+%s+and+activityDateTime+le+%s" % (api_version, query_date, time_throttle)
             helper.log_debug("_Splunk_ input_name=%s Audit URL used: %s" % (input_name, url))
             max_activityDate = query_date
     

--- a/package/bin/MS_AAD_device.py
+++ b/package/bin/MS_AAD_device.py
@@ -71,7 +71,7 @@ class ModInputMS_AAD_device(base_mi.BaseModInput):
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
-        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+        scheme.add_argument(smi.Argument("api_version", title="API Version",
                                          description="",
                                          required_on_create=False,
                                          required_on_edit=False))
@@ -91,7 +91,7 @@ class ModInputMS_AAD_device(base_mi.BaseModInput):
         tenant_id = helper.get_arg("tenant_id")
         event_source = "%s:tenant_id:%s" % (helper.input_type, tenant_id)
         source_type = helper.get_arg("device_sourcetype")
-        endpoint = helper.get_arg("endpoint")
+        api_version = helper.get_arg("api_version")
         input_name = helper.get_input_stanza_names()
         
         environment = helper.get_arg("environment")
@@ -101,7 +101,7 @@ class ModInputMS_AAD_device(base_mi.BaseModInput):
         
         if(session):
             helper.log_debug("_Splunk_ input_name=%s Collecting device data." % input_name)
-            url = graph_base_url + "/%s/devices" % endpoint
+            url = graph_base_url + "/%s/devices" % api_version
             
             response = azutils.get_items_batch_session(helper=helper, url=url, session=session)
             items = None if response == None else response['value']

--- a/package/bin/MS_AAD_group.py
+++ b/package/bin/MS_AAD_group.py
@@ -75,7 +75,7 @@ class ModInputMS_AAD_group(base_mi.BaseModInput):
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
-        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+        scheme.add_argument(smi.Argument("api_version", title="API Version",
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
@@ -96,7 +96,7 @@ class ModInputMS_AAD_group(base_mi.BaseModInput):
         event_source = "%s:tenant_id:%s" % (helper.input_type, tenant_id)
         source_type = helper.get_arg("group_sourcetype")
         filter = helper.get_arg("filter")
-        endpoint = helper.get_arg("endpoint")
+        api_version = helper.get_arg("api_version")
         input_name = helper.get_input_stanza_names()
         
         environment = helper.get_arg("environment")
@@ -105,7 +105,7 @@ class ModInputMS_AAD_group(base_mi.BaseModInput):
         session = azauth.get_graph_session(client_id, client_secret, tenant_id, environment, helper)
         if(session):
             helper.log_debug("_Splunk_ input_name=%s Collecting group data." % input_name)
-            url = graph_base_url + "/%s/groups/" % endpoint
+            url = graph_base_url + "/%s/groups/" % api_version
             if(filter):
                 url = "%s?%s" % (url, filter)
             

--- a/package/bin/MS_AAD_identity_protection.py
+++ b/package/bin/MS_AAD_identity_protection.py
@@ -82,7 +82,7 @@ class ModInputMS_AAD_identity_protection(base_mi.BaseModInput):
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
-        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+        scheme.add_argument(smi.Argument("api_version", title="API Version",
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
@@ -102,7 +102,7 @@ class ModInputMS_AAD_identity_protection(base_mi.BaseModInput):
         subscription_id = helper.get_arg("subscription_id")
         tenant_id = helper.get_arg("tenant_id")
         event_source = "%s:tenant_id:%s" % (helper.input_type, tenant_id)
-        endpoint = helper.get_arg("endpoint")
+        api_version = helper.get_arg("api_version")
         environment = helper.get_arg("environment")
         input_name = helper.get_input_stanza_names()
         
@@ -126,11 +126,11 @@ class ModInputMS_AAD_identity_protection(base_mi.BaseModInput):
                 
                 if risk_detection_check_point in [None,'']:
                     helper.log_debug("_Splunk_ input_name=%s No risk detection data checkpoint. Collecting all current events." % input_name)
-                    url = graph_base_url + "/%s/identityProtection/riskDetections" % (endpoint)
+                    url = graph_base_url + "/%s/identityProtection/riskDetections" % (api_version)
                     risk_detection_check_point = ""
                 else:
                     helper.log_debug("_Splunk_ input_name=%s Found risk detction checkpoint: %s. Collecting events after this detected date/time" % (input_name, risk_detection_check_point))
-                    url = graph_base_url + "/%s/identityProtection/riskDetections?$orderby=lastUpdatedDateTime&$filter=lastUpdatedDateTime gt %s" % (endpoint, risk_detection_check_point)
+                    url = graph_base_url + "/%s/identityProtection/riskDetections?$orderby=lastUpdatedDateTime&$filter=lastUpdatedDateTime gt %s" % (api_version, risk_detection_check_point)
     
                 response = azutils.get_items_batch_session(helper=helper, url=url, session=session)
                 items = None if response == None else response['value']
@@ -161,11 +161,11 @@ class ModInputMS_AAD_identity_protection(base_mi.BaseModInput):
                 
                 if risky_user_check_point in [None,'']:
                     helper.log_debug("_Splunk_ input_name=%s No risky user data checkpoint. Collecting all current events." % input_name)
-                    url = graph_base_url + "/%s/identityProtection/riskyUsers" % (endpoint)
+                    url = graph_base_url + "/%s/identityProtection/riskyUsers" % (api_version)
                     risky_user_check_point = ""
                 else:
                     helper.log_debug("_Splunk_ input_name=%s Found risky user checkpoint: %s. Collecting events after this detected date/time" % (input_name, risky_user_check_point))
-                    url = graph_base_url + "/%s/identityProtection/riskyUsers?$orderby=riskLastUpdatedDateTime&$filter=riskLastUpdatedDateTime gt %s" % (endpoint, risky_user_check_point)
+                    url = graph_base_url + "/%s/identityProtection/riskyUsers?$orderby=riskLastUpdatedDateTime&$filter=riskLastUpdatedDateTime gt %s" % (api_version, risky_user_check_point)
                 
                 response = azutils.get_items_batch_session(helper=helper, url=url, session=session)
                 items = None if response == None else response['value']

--- a/package/bin/MS_AAD_signins.py
+++ b/package/bin/MS_AAD_signins.py
@@ -109,7 +109,7 @@ class ModInputMS_AAD_signins(base_mi.BaseModInput):
                                          description="Advanced: number of seconds to subtract from the end date of the query. This helps accommodate near real-time events toward the end of a query that may arrive non sequentially.",
                                          required_on_create=True,
                                          required_on_edit=False))
-        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+        scheme.add_argument(smi.Argument("api_version", title="API Version",
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
@@ -153,7 +153,7 @@ class ModInputMS_AAD_signins(base_mi.BaseModInput):
         query_window_size = int(helper.get_arg("query_window_size"))
         query_backoff_throttle = int(helper.get_arg("query_backoff_throttle"))
         input_filter = helper.get_arg("filter")
-        endpoint = helper.get_arg("endpoint")
+        api_version = helper.get_arg("api_version")
         input_name = helper.get_input_stanza_names()
         
         environment = helper.get_arg("environment")
@@ -166,12 +166,12 @@ class ModInputMS_AAD_signins(base_mi.BaseModInput):
         
             if(query_window_size > 0):
                 end_date = azutils.get_end_date(helper, query_date, query_window_size)
-                url = graph_base_url + "/%s/auditLogs/signIns?$orderby=createdDateTime&$filter=createdDateTime+ge+%s+and+createdDateTime+le+%s" % (endpoint, query_date, end_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ'))
+                url = graph_base_url + "/%s/auditLogs/signIns?$orderby=createdDateTime&$filter=createdDateTime+ge+%s+and+createdDateTime+le+%s" % (api_version, query_date, end_date.strftime('%Y-%m-%dT%H:%M:%S.%fZ'))
                 helper.log_debug("_Splunk_ input_name=%s Query limit specified: %s" % (input_name, str(query_window_size)))
             else:
                 time_throttle_unformatted = datetime.datetime.utcnow() - datetime.timedelta(seconds=query_backoff_throttle)
                 time_throttle = time_throttle_unformatted.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-                url = graph_base_url + "/%s/auditLogs/signIns?$orderby=createdDateTime&$filter=createdDateTime+gt+%s+and+createdDateTime+le+%s" % (endpoint, query_date, time_throttle)
+                url = graph_base_url + "/%s/auditLogs/signIns?$orderby=createdDateTime&$filter=createdDateTime+gt+%s+and+createdDateTime+le+%s" % (api_version, query_date, time_throttle)
 
             # Insert the user filter if provided
             if(input_filter):

--- a/package/bin/MS_AAD_user.py
+++ b/package/bin/MS_AAD_user.py
@@ -74,7 +74,7 @@ class ModInputMS_AAD_user(base_mi.BaseModInput):
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
-        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+        scheme.add_argument(smi.Argument("api_version", title="API Version",
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
@@ -95,7 +95,7 @@ class ModInputMS_AAD_user(base_mi.BaseModInput):
         event_source = "%s:tenant_id:%s" % (helper.input_type, tenant_id)
         source_type = helper.get_arg("user_sourcetype")
         filter = helper.get_arg("filter")
-        endpoint = helper.get_arg("endpoint")
+        api_version = helper.get_arg("api_version")
         input_name = helper.get_input_stanza_names()
         
         environment = helper.get_arg("environment")
@@ -104,7 +104,7 @@ class ModInputMS_AAD_user(base_mi.BaseModInput):
         session = azauth.get_graph_session(client_id, client_secret, tenant_id, environment, helper)
         if(session):
             helper.log_debug("_Splunk_ input_name=%s Collecting user data." % input_name)
-            url = graph_base_url + "/%s/users" % endpoint
+            url = graph_base_url + "/%s/users" % api_version
             if(filter):
                 url = "%s?%s" % (url, filter)
     

--- a/package/bin/ms_graph_security.py
+++ b/package/bin/ms_graph_security.py
@@ -97,7 +97,7 @@ class ModInputms_graph_security(base_mi.BaseModInput):
                                          description="The date/time to start collecting data.  If no value is give, the input will start getting data 7 days in the past.",
                                          required_on_create=False,
                                          required_on_edit=False))
-        scheme.add_argument(smi.Argument("endpoint", title="Endpoint",
+        scheme.add_argument(smi.Argument("api_version", title="API Version",
                                          description="",
                                          required_on_create=True,
                                          required_on_edit=False))
@@ -135,7 +135,7 @@ class ModInputms_graph_security(base_mi.BaseModInput):
         event_source = "%s:tenant_id:%s" % (helper.input_type, tenant_id)
         source_type = helper.get_arg("graph_security_api_sourcetype")
         input_filter = helper.get_arg("filter")
-        endpoint = helper.get_arg("endpoint")
+        api_version = helper.get_arg("api_version")
         input_name = helper.get_input_stanza_names()
         
         environment = helper.get_arg("environment")
@@ -146,7 +146,7 @@ class ModInputms_graph_security(base_mi.BaseModInput):
         
         if(session):
             
-            url = graph_base_url + "/%s/security/alerts?$orderby=lastModifiedDateTime&$filter=lastModifiedDateTime+gt+%s" % (endpoint, query_date)
+            url = graph_base_url + "/%s/security/alerts?$orderby=lastModifiedDateTime&$filter=lastModifiedDateTime+gt+%s" % (api_version, query_date)
 
             # Insert the user filter if provided
             if(input_filter):

--- a/package/default/inputs.conf
+++ b/package/default/inputs.conf
@@ -1,29 +1,29 @@
 [MS_AAD_signins]
-endpoint = v1.0
+api_version = v1.0
 python.version = python3
 
 [MS_AAD_user]
-endpoint = v1.0
+api_version = v1.0
 python.version = python3
 
 [MS_AAD_group]
-endpoint = v1.0
+api_version = v1.0
 python.version = python3
 
 [MS_AAD_app]
-endpoint = v1.0
+api_version = v1.0
 python.version = python3
 
 [MS_AAD_audit]
-endpoint = v1.0
+api_version = v1.0
 python.version = python3
 
 [MS_AAD_identity_protection]
-endpoint = v1.0
+api_version = v1.0
 python.version = python3
 
 [MS_AAD_device]
-endpoint = v1.0
+api_version = v1.0
 python.version = python3
 
 [azure_metrics]


### PR DESCRIPTION
The Microsoft Graph Security API exposes multiple resource endpoints (e.g., alerts, incidents), but currently, only alerts is supported in this implementation.

While reviewing the code related to issue #96, I noticed that the input parameter named endpoint is actually being used to specify the API version (e.g., v1.0), not the actual resource endpoint. This is a bit misleading in terms of naming.

In this pull request, I've renamed the endpoint parameter to api_version to better reflect its purpose.

As a follow-up, I plan to introduce a new parameter named endpoint to specify the actual resource (e.g., alerts, incidents), which will make the module more flexible and allow support for other Graph Security API endpoints in the future.